### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/xyz.parlatype.Parlatype.json
+++ b/xyz.parlatype.Parlatype.json
@@ -15,11 +15,8 @@
         "--socket=pulseaudio"
     ],
     "cleanup": [
-        "*.la",
-        "*.a",
         "/include",
         "/lib/pkgconfig",
-        "/libexec",
         "/share/man"
     ],
     "modules": [


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.